### PR TITLE
Add Windows Service installation reference to runner-install page

### DIFF
--- a/docs/administration/runner/runner-installation/runner-install.md
+++ b/docs/administration/runner/runner-installation/runner-install.md
@@ -44,6 +44,12 @@ The Runner can be installed as a `systemd` service on Linux systems.
     # sudo service runner start
     ```
 
+## Windows Service for the Runner
+
+For Windows environments, the Runner can be installed as a Windows service using either Apache Commons Daemon or NSSM. This ensures the Runner starts automatically with the system and runs in the background.
+
+See the [Enterprise Runner as Windows Service](/learning/howto/runner-service-windows.html) guide for detailed installation instructions.
+
 ## Manual Docker Installation
 
 The standard method for deploying the Runner with Docker is with `docker-compose` as outlined in the [Creating Runner](/administration/runner/runner-installation/creating-runners.md) documentation by selecting **`Docker`** for the **Platform**.


### PR DESCRIPTION
## Summary
- Add reference to the Enterprise Runner as Windows Service guide in the Advanced Installation Options page
- Position the new section after Linux Service section for logical grouping of platform-specific installations
- Provides Windows users with a clear path to service installation options

## Context
The Advanced Installation Options page covered Linux service installation and Docker methods but had no mention of Windows service installation, even though a comprehensive guide exists at `/learning/howto/runner-service-windows.html`. This creates a documentation gap for Windows users.

## Changes
- Added "Windows Service for the Runner" section with brief description and link to detailed guide

## Test plan
- [ ] Verify link resolves correctly in local docs build
- [ ] Confirm section placement flows logically after Linux Service section
- [ ] Review formatting and consistency with existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)